### PR TITLE
Correct app-insight-connection-key alias

### DIFF
--- a/adoption-cron/values.yaml
+++ b/adoption-cron/values.yaml
@@ -20,10 +20,6 @@ job:
           alias: LAUNCH_DARKLY_SDK_KEY
         - name: AppInsightsInstrumentationKey
           alias: APP_INSIGHTS_KEY
-        - name: send-grid-api-key
-          alias: SEND_GRID_API_KEY
-        - name: sendgrid-notify-from-email
-          alias: SEND_GRID_NOTIFY_FROM_EMAIL
         - name: app-insight-connection-key
           alias: app-insight-connection-key
   environment:

--- a/adoption-cron/values.yaml
+++ b/adoption-cron/values.yaml
@@ -20,8 +20,12 @@ job:
           alias: LAUNCH_DARKLY_SDK_KEY
         - name: AppInsightsInstrumentationKey
           alias: APP_INSIGHTS_KEY
+        - name: send-grid-api-key
+          alias: SEND_GRID_API_KEY
+        - name: sendgrid-notify-from-email
+          alias: SEND_GRID_NOTIFY_FROM_EMAIL
         - name: app-insight-connection-key
-          alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+          alias: app-insight-connection-key
   environment:
     ADOPTION_WEB_CLIENT_ID: adoption-web
     ADOPTION_WEB_MICROSERVICE: adoption_web


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
When adding a new cron we realised that the existing cron logs weren't being added to application insights.  This corrects the alias.

**This should not be merged until it's confirmed there's no personal data in the logs.**

### Testing done
Tested correct application insights alias with cron job in demo.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
