### PR TITLE
Correct app-insight-connection-key alias

### DIFF
--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -21,7 +21,7 @@ job:
         - name: AppInsightsInstrumentationKey
           alias: APP_INSIGHTS_KEY  
         - name: app-insight-connection-key
-          alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+          alias: app-insight-connection-key
   environment:
     ADOPTION_WEB_CLIENT_ID: adoption-web
     ADOPTION_WEB_MICROSERVICE: adoption_web


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Logs aren't being ingested by Application Insights.  Correcting alias.

### Testing done
Tested in demo with correct alias.

### Checklist
- [ ] Does this PR introduce a breaking change
