### PR TITLE
ADOP-2665: Update adoption-cron to use OCI

### DIFF
--- a/adoption-cron/Chart.yaml
+++ b/adoption-cron/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 dependencies:
   - name: job
     version: 2.1.1
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    repository: oci://hmctspublic.azurecr.io/helm


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ADOP-2665](https://tools.hmcts.net/jira/browse/ADOP-2665)

### Change description
 - Change url to use OCI, not http
 
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
